### PR TITLE
🔗 ci update to make release drafts

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v3
         with:
-          name: wheels
+          name: wheels-linux-${{ matrix.target }}
           path: dist
 
   windows:
@@ -60,7 +60,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v3
         with:
-          name: wheels
+          name: wheels-windows-${{ matrix.target }}
           path: dist
 
   macos:
@@ -82,7 +82,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v3
         with:
-          name: wheels
+          name: wheels-macos-${{ matrix.target }}
           path: dist
 
   sdist:
@@ -97,7 +97,7 @@ jobs:
       - name: Upload sdist
         uses: actions/upload-artifact@v3
         with:
-          name: wheels
+          name: sdist
           path: dist
 
   release:
@@ -106,13 +106,35 @@ jobs:
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
     needs: [linux, windows, macos, sdist]
     steps:
-      - uses: actions/download-artifact@v4.1.7
+      - name: Download Linux wheels
+        uses: actions/download-artifact@v3
         with:
-          name: wheels
+          name: wheels-linux-x86_64
+          path: ./dist-linux-x86_64
+      - name: Download Windows wheels
+        uses: actions/download-artifact@v3
+        with:
+          name: wheels-windows-x64
+          path: ./dist-windows-x64
+      - name: Download MacOS wheels
+        uses: actions/download-artifact@v3
+        with:
+          name: wheels-macos-x86_64
+          path: ./dist-macos-x86_64
+      - name: Download sdist
+        uses: actions/download-artifact@v3
+        with:
+          name: sdist
+          path: ./dist-sdist
+
       - name: Create Draft Release
         uses: softprops/action-gh-release@v1
         with:
           draft: true
-          files: dist/*
+          files: |
+            ./dist-linux-x86_64/*
+            ./dist-windows-x64/*
+            ./dist-macos-x86_64/*
+            ./dist-sdist/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   linux:
@@ -101,18 +101,18 @@ jobs:
           path: dist
 
   release:
-    name: Release
+    name: Draft GitHub Release
     runs-on: ubuntu-latest
-    if: "startsWith(github.ref, 'refs/tags/')"
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
     needs: [linux, windows, macos, sdist]
     steps:
       - uses: actions/download-artifact@v4.1.7
         with:
           name: wheels
-      - name: Publish to PyPI
-        uses: PyO3/maturin-action@v1
-        env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Create Draft Release
+        uses: softprops/action-gh-release@v1
         with:
-          command: upload
-          args: --skip-existing *
+          draft: true
+          files: dist/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request introduces several updates to the CI workflow configuration in the `.github/workflows/CI.yml` file. The changes include modifying permissions, updating artifact names for different platforms, and reworking the release job to create a draft GitHub release instead of directly publishing to PyPI.

### Permissions Update:
* Changed `contents` permission from `read` to `write` to allow the workflow to create releases. (`[.github/workflows/CI.ymlL17-R17](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8L17-R17)`)

### Artifact Naming:
* Updated artifact names to include the platform and target architecture for better organization:
  * Linux: `wheels-linux-${{ matrix.target }}` (`[.github/workflows/CI.ymlL40-R40](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8L40-R40)`)
  * Windows: `wheels-windows-${{ matrix.target }}` (`[.github/workflows/CI.ymlL63-R63](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8L63-R63)`)
  * MacOS: `wheels-macos-${{ matrix.target }}` (`[.github/workflows/CI.ymlL85-R85](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8L85-R85)`)
  * Source distribution (sdist): `sdist` (`[.github/workflows/CI.ymlL100-R140](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8L100-R140)`)

### Release Job Overhaul:
* Renamed the job to "Draft GitHub Release" and adjusted the trigger conditions to run on the `main` or `master` branches. (`[.github/workflows/CI.ymlL100-R140](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8L100-R140)`)
* Added steps to download artifacts for each platform and create a draft release with these artifacts. (`[.github/workflows/CI.ymlL100-R140](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8L100-R140)`)